### PR TITLE
:sparkles: Socket connection upgraded to ObjectStream

### DIFF
--- a/src/main/java/client/gui/user/common/ChatHandler.java
+++ b/src/main/java/client/gui/user/common/ChatHandler.java
@@ -1,9 +1,10 @@
 package client.gui.user.common;
 
+import common.Message;
+
 import javax.swing.*;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
 import java.net.Socket;
 
 public class ChatHandler implements Runnable {
@@ -15,22 +16,24 @@ public class ChatHandler implements Runnable {
         this.userMessageLabel = userMessageLabel;
     }
 
-    /**
-     * Runs this operation.
-     */
     @Override
     public void run() {
         try {
             Socket socket = new Socket("localhost", 3001);
-            BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
             while (true) {
-                String message = in.readLine();
-                chatArea.append(message + "\n");
+                ObjectInputStream in = new ObjectInputStream(socket.getInputStream());
+
+                // we have message object now
+                Message message = (Message) in.readObject();
+
+                chatArea.append(message.getUser().getNickname() + ":"+message.getMessageText() + "\n");
                 userMessageLabel.setText("New message received");
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            System.out.println(e.getMessage());
             userMessageLabel.setText("Connection error");
+        } catch (ClassNotFoundException e) {
+            System.out.println(e.getMessage());
         }
     }
 }

--- a/src/main/java/server/Server.java
+++ b/src/main/java/server/Server.java
@@ -5,7 +5,7 @@ import common.Chat;
 import common.Message;
 
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.ObjectOutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.rmi.RemoteException;
@@ -88,12 +88,11 @@ public class Server extends UnicastRemoteObject implements ServerInterface {
             // send message using socket
             try {
                 Socket socket = user.getSocket();
-                PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
-                writer.println(message);
+                ObjectOutputStream out = new ObjectOutputStream(socket.getOutputStream());
+                out.writeObject(message);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-//            user.setChatHome(user.getChatHome());
         }
     }
 


### PR DESCRIPTION
This pull request refactors the messaging system in the chat application to use serialized `Message` objects instead of raw text strings. This change improves the structure and flexibility of message handling. Key updates include replacing `BufferedReader` and `PrintWriter` with `ObjectInputStream` and `ObjectOutputStream` respectively, and updating the client and server logic accordingly.

### Client-side changes:
* [`src/main/java/client/gui/user/common/ChatHandler.java`](diffhunk://#diff-e42f1c67955f96e61541687a816b061525fb8b24fca9ea0cf32f64fd02c3a6c7R3-R7): Replaced `BufferedReader` with `ObjectInputStream` to read serialized `Message` objects. Updated the `run` method to handle `Message` objects, displaying the sender's nickname and message text in the chat area. Added handling for `ClassNotFoundException` and improved error logging. [[1]](diffhunk://#diff-e42f1c67955f96e61541687a816b061525fb8b24fca9ea0cf32f64fd02c3a6c7R3-R7) [[2]](diffhunk://#diff-e42f1c67955f96e61541687a816b061525fb8b24fca9ea0cf32f64fd02c3a6c7L18-R36)

### Server-side changes:
* [`src/main/java/server/Server.java`](diffhunk://#diff-7f1d3a122de41f204eb62f244a63ec5b045497750487ae13ca698685a245dda7L8-R8): Replaced `PrintWriter` with `ObjectOutputStream` to send serialized `Message` objects in the `sendBroadcastMessage` method. This ensures consistent serialization of messages between the server and clients. [[1]](diffhunk://#diff-7f1d3a122de41f204eb62f244a63ec5b045497750487ae13ca698685a245dda7L8-R8) [[2]](diffhunk://#diff-7f1d3a122de41f204eb62f244a63ec5b045497750487ae13ca698685a245dda7L91-L96)