### PR TITLE
:card_file_box: Update modela

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>7.0.0.Beta1</version>

--- a/src/main/java/models/Chat.java
+++ b/src/main/java/models/Chat.java
@@ -1,0 +1,95 @@
+package models;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "chats")
+public class Chat {
+    @Id
+    @Column(name = "chat_id", nullable = false)
+    private Integer id;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private models.User admin;
+
+    @Column(name = "start_time")
+    private Instant startTime;
+
+    @Column(name = "end_time")
+    private Instant endTime;
+
+    @ColumnDefault("0")
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @ColumnDefault("current_timestamp()")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public models.User getAdmin() {
+        return admin;
+    }
+
+    public void setAdmin(models.User admin) {
+        this.admin = admin;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Instant startTime) {
+        this.startTime = startTime;
+    }
+
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Instant endTime) {
+        this.endTime = endTime;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+}

--- a/src/main/java/models/ChatFile.java
+++ b/src/main/java/models/ChatFile.java
@@ -1,0 +1,61 @@
+package models;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "chat_files")
+public class ChatFile {
+    @Id
+    @Column(name = "file_id", nullable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private models.Chat chat;
+
+    @Column(name = "file_path", nullable = false)
+    private String filePath;
+
+    @ColumnDefault("current_timestamp()")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public models.Chat getChat() {
+        return chat;
+    }
+
+    public void setChat(models.Chat chat) {
+        this.chat = chat;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+}

--- a/src/main/java/models/ChatMessage.java
+++ b/src/main/java/models/ChatMessage.java
@@ -1,0 +1,75 @@
+package models;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "chat_messages")
+public class ChatMessage {
+    @Id
+    @Column(name = "message_id", nullable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private models.Chat chat;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private models.User user;
+
+    @Lob
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @ColumnDefault("current_timestamp()")
+    @Column(name = "sent_at", nullable = false)
+    private Instant sentAt;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public models.Chat getChat() {
+        return chat;
+    }
+
+    public void setChat(models.Chat chat) {
+        this.chat = chat;
+    }
+
+    public models.User getUser() {
+        return user;
+    }
+
+    public void setUser(models.User user) {
+        this.user = user;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Instant getSentAt() {
+        return sentAt;
+    }
+
+    public void setSentAt(Instant sentAt) {
+        this.sentAt = sentAt;
+    }
+
+}

--- a/src/main/java/models/User.java
+++ b/src/main/java/models/User.java
@@ -1,0 +1,117 @@
+package models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Integer id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "username", nullable = false, length = 50)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nick_name", nullable = false, length = 50)
+    private String nickName;
+
+    @Column(name = "profile_picture_path")
+    private String profilePicturePath;
+
+    @ColumnDefault("0")
+    @Column(name = "is_admin")
+    private Boolean isAdmin;
+
+    @ColumnDefault("current_timestamp()")
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ColumnDefault("current_timestamp()")
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getNickName() {
+        return nickName;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public String getProfilePicturePath() {
+        return profilePicturePath;
+    }
+
+    public void setProfilePicturePath(String profilePicturePath) {
+        this.profilePicturePath = profilePicturePath;
+    }
+
+    public Boolean getIsAdmin() {
+        return isAdmin;
+    }
+
+    public void setIsAdmin(Boolean isAdmin) {
+        this.isAdmin = isAdmin;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+}

--- a/src/main/java/models/UserChat.java
+++ b/src/main/java/models/UserChat.java
@@ -1,0 +1,64 @@
+package models;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "user_chats")
+public class UserChat {
+    @EmbeddedId
+    private UserChatId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private models.User user;
+
+    @MapsId("chatId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private Chat chat;
+
+    @ColumnDefault("current_timestamp()")
+    @Column(name = "subscribed_at", nullable = false)
+    private Instant subscribedAt;
+
+    public UserChatId getId() {
+        return id;
+    }
+
+    public void setId(UserChatId id) {
+        this.id = id;
+    }
+
+    public models.User getUser() {
+        return user;
+    }
+
+    public void setUser(models.User user) {
+        this.user = user;
+    }
+
+    public Chat getChat() {
+        return chat;
+    }
+
+    public void setChat(Chat chat) {
+        this.chat = chat;
+    }
+
+    public Instant getSubscribedAt() {
+        return subscribedAt;
+    }
+
+    public void setSubscribedAt(Instant subscribedAt) {
+        this.subscribedAt = subscribedAt;
+    }
+
+}

--- a/src/main/java/models/UserChatId.java
+++ b/src/main/java/models/UserChatId.java
@@ -1,0 +1,48 @@
+package models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import org.hibernate.Hibernate;
+
+import java.util.Objects;
+
+@Embeddable
+public class UserChatId implements java.io.Serializable {
+    private static final long serialVersionUID = -5463665516030491895L;
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "chat_id", nullable = false)
+    private Integer chatId;
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public Integer getChatId() {
+        return chatId;
+    }
+
+    public void setChatId(Integer chatId) {
+        this.chatId = chatId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        UserChatId entity = (UserChatId) o;
+        return Objects.equals(this.chatId, entity.chatId) &&
+                Objects.equals(this.userId, entity.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(chatId, userId);
+    }
+
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <persistence xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
-             version="3.2">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
     <persistence-unit name="default">
 
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/chat_application"/>
+            <property name="jakarta.persistence.jdbc.user" value="root"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="update"/>
+            <property name="hibernate.show_sql" value="true"/>
+        </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
This pull request introduces a foundational data model for a chat application using JPA and Hibernate. It includes the creation of several entity classes, a composite key class, and updates to the project configuration to support MySQL as the database. Below are the key changes grouped by theme:

### Database Configuration:
* Added MySQL dependency to `pom.xml` to enable database connectivity (`mysql-connector-java`, version 8.0.33).
* Updated `persistence.xml` to configure the MySQL database connection, Hibernate properties, and schema generation settings.

### Entity Models:
* Created the `Chat` entity to represent chat rooms, including fields such as `title`, `admin`, and timestamps for creation and activity.
* Added the `User` entity to represent application users, with fields for `email`, `username`, and profile details.
* Implemented the `ChatMessage` entity to store messages within chats, linking to both `Chat` and `User`.
* Added the `ChatFile` entity to manage file attachments associated with chats.

### Relationships and Composite Keys:
* Introduced the `UserChat` entity to represent many-to-many relationships between users and chats, with a composite key (`UserChatId`) to handle the association. [[1]](diffhunk://#diff-62246b43937559205eb3a958186d64d222e3db4c5225d8c3291852c57b8a1434R1-R64) [[2]](diffhunk://#diff-091be7d5cbbe5cacbb4974baf9bb0d213e7566d673ce0103d8533bc599095b32R1-R48)