### PR TITLE
User able to see available chat retrieve from database

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/client/gui/shared/ChatScreen.java
+++ b/src/main/java/client/gui/shared/ChatScreen.java
@@ -71,6 +71,17 @@ public class ChatScreen extends JPanel {
         sendButton.addActionListener(( e) -> {
             sendMessage(messageField.getText().trim());
         });
+
+        chatList.addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                int selectedIndex = chatList.getSelectedIndex();
+                if (selectedIndex >= 0 && selectedIndex < chats.size()) {
+                    Chat selectedChat = chats.get(selectedIndex);
+                    int chatId = selectedChat.getId();
+                    loadChatMessages(chatId);
+                }
+            }
+        });
     }
 
     private DefaultListModel<String> getChatList() {
@@ -163,5 +174,32 @@ public class ChatScreen extends JPanel {
         inputPanel.add(sendButton, BorderLayout.EAST);
         inputPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
         rightPanel.add(inputPanel, BorderLayout.SOUTH);
+    }
+
+    private void loadChatMessages(int chatId) {
+        EntityManager em = HibernateUtil.getEmf().createEntityManager();
+        String query = "select m from ChatMessage m where m.chat.id=:chatId";
+        TypedQuery<ChatMessage> q = em.createQuery(query, ChatMessage.class);
+        System.out.println("Loading Chat Messages for " + chatId);
+        q.setParameter("chatId", chatId);
+
+        // clear old list
+        messages.clear();
+        messages.addAll(q.getResultList());
+
+//        print for testing
+        for (ChatMessage message : messages) {
+            System.out.println(message.getMessage());
+        }
+
+        displayChatMessages();
+    }
+
+    private void displayChatMessages() {
+        // clear chat ares
+        chatArea.setText("");
+        for (ChatMessage message : messages) {
+            chatArea.append(message.getUser().getNickName() + ":"+message.getMessage() + "\n");
+        }
     }
 }

--- a/src/main/java/client/gui/shared/ChatScreen.java
+++ b/src/main/java/client/gui/shared/ChatScreen.java
@@ -22,6 +22,7 @@ public class ChatScreen extends JPanel {
     private final ArrayList<Chat> chats = new ArrayList<>();
     private final ArrayList<ChatMessage> messages = new ArrayList<>();
     private final AppScreen screen;
+    private Chat activeChat;
 
     // swing component
     private JTextArea chatArea;
@@ -78,10 +79,22 @@ public class ChatScreen extends JPanel {
                 if (selectedIndex >= 0 && selectedIndex < chats.size()) {
                     Chat selectedChat = chats.get(selectedIndex);
                     int chatId = selectedChat.getId();
+                    // get active chat from database
+                    EntityManager em = HibernateUtil.getEmf().createEntityManager();
+                    Chat chatEntity = em.find(Chat.class,chatId);
+                    setActiveChat(chatEntity);
                     loadChatMessages(chatId);
                 }
             }
         });
+    }
+
+    public Chat getActiveChat() {
+        return activeChat;
+    }
+
+    public void setActiveChat(Chat activeChat) {
+        this.activeChat = activeChat;
     }
 
     private DefaultListModel<String> getChatList() {
@@ -119,15 +132,12 @@ public class ChatScreen extends JPanel {
 
         EntityManager em = HibernateUtil.getEmf().createEntityManager();
         User MessageSender = em.find(User.class, 1);
-        System.out.println(MessageSender);
+
         messageObj.setUser(MessageSender);
         em.close();
 
-        // get sample chat to assign
-        EntityManager em2 = HibernateUtil.getEmf().createEntityManager();
-        Chat chat = em2.find(Chat.class, 1);
-        messageObj.setChat(chat);
-        em2.close();
+        // set active chat to message owner
+        messageObj.setChat(activeChat);
 
         //set time
         messageObj.setSentAt(new Date().toInstant());


### PR DESCRIPTION
This pull request introduces changes to enhance the functionality of the `ChatScreen` class by adding support for selecting and displaying messages from an active chat. Additionally, a minor configuration update was made to the project settings. The most important changes include the addition of an `activeChat` property, the implementation of chat selection and message loading, and the use of the active chat when sending messages.

### Enhancements to `ChatScreen` functionality:

* Added a new `activeChat` property to manage the currently selected chat, along with getter and setter methods (`src/main/java/client/gui/shared/ChatScreen.java`). [[1]](diffhunk://#diff-aae77b872f0bfd81b35328b9bbae0a2c060921242744c8e48aea8ecd1a9d73adR25) [[2]](diffhunk://#diff-aae77b872f0bfd81b35328b9bbae0a2c060921242744c8e48aea8ecd1a9d73adR75-R97)
* Implemented a `ListSelectionListener` for the chat list to set the `activeChat` and load messages from the database for the selected chat (`src/main/java/client/gui/shared/ChatScreen.java`).
* Added a `loadChatMessages` method to fetch and display messages for the active chat, and a `displayChatMessages` method to render messages in the chat area (`src/main/java/client/gui/shared/ChatScreen.java`).
* Updated the `sendMessage` method to associate new messages with the `activeChat` instead of a hardcoded chat (`src/main/java/client/gui/shared/ChatScreen.java`).

### Project configuration update:

* Updated the `languageLevel` in `.idea/misc.xml` from `JDK_X` to `JDK_23` to align with the project's Java version (`.idea/misc.xml`).