### PR TITLE
:sparkles: Display Join Message

### DIFF
--- a/src/main/java/server/Server.java
+++ b/src/main/java/server/Server.java
@@ -37,7 +37,6 @@ public class Server extends UnicastRemoteObject implements ServerInterface {
                 try {
                     Socket socket = serverSocket.accept();
 
-
                     UserClient user = new UserClient(2, "Asela");
                     user.setSocket(socket);
                     addOnlineUser(user);


### PR DESCRIPTION
This pull request introduces changes to enhance the chat display functionality and improve error handling in the `ChatArea` class, as well as a minor cleanup in the `Server` class. The key updates include adding functionality to display when users join a chat, retrieving subscriber data from the database, and replacing a specific exception with a generic one for broader error handling.

### Enhancements to chat display functionality:

* [`src/main/java/client/gui/shared/ChatArea.java`](diffhunk://#diff-80daa2a71c8d20a410b4e240e0f362cfccfbc450c50c11f3e32336ef5e1b7605R208-R247): Added a new private method `getSubscribers()` to retrieve a list of chat subscribers from the database. This includes querying the `UserChat` entity for subscribers based on the chat ID.
* [`src/main/java/client/gui/shared/ChatArea.java`](diffhunk://#diff-80daa2a71c8d20a410b4e240e0f362cfccfbc450c50c11f3e32336ef5e1b7605R208-R247): Updated the `displayChatMessages()` method to display a message when a user joins the chat. This involves checking if a subscriber joined before a message was sent and appending the corresponding information to the chat area.

### Error handling improvements:

* [`src/main/java/client/gui/shared/ChatArea.java`](diffhunk://#diff-80daa2a71c8d20a410b4e240e0f362cfccfbc450c50c11f3e32336ef5e1b7605L238-R267): Replaced the `BadLocationException` catch block in `displayChatMessages()` with a generic `Exception` to handle a broader range of errors.

### Code cleanup:

* [`src/main/java/server/Server.java`](diffhunk://#diff-7f1d3a122de41f204eb62f244a63ec5b045497750487ae13ca698685a245dda7L40): Removed an unnecessary blank line in the `listenForUsers()` method for better readability.